### PR TITLE
Merge changes Upstream. New parsed tags and updated tests

### DIFF
--- a/.github/workflows/Run_Tests.yml
+++ b/.github/workflows/Run_Tests.yml
@@ -1,0 +1,28 @@
+name: Python tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+#    env:
+#      DISPLAY: ":99.0"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.8','3.9', ]
+    name: Python ${{ matrix.python-version }} sample
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - run: pip install -r requirements.txt
+#      - run: sudo apt install xvfb
+#      - name: Start xvfb
+#        run: |
+#          Xvfb :99 -screen 0 1920x1080x24 &disown
+      - name: Run the tests
+        run: python3 -m unittest discover -s tests -t .

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,13 +50,11 @@ COPY root/ /
 RUN \
   echo "Install dependencies" && \
   echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-  apk add --no-cache --update python3 py3-pip python3-tkinter py3-numpy py3-multidict py3-yarl \
+  apk add --no-cache --update \
+    python3 py3-pip py3-numpy py3-multidict py3-yarl \
     py3-psutil py3-watchdog py3-requests py3-tz \
-    build-base jpeg-dev zlib-dev \
-    python3-dev
-
-RUN \
-  pip3 install pymongo python_json_logger image BeautifulSoup4 && \
+    build-base jpeg-dev zlib-dev python3-dev && \
+  pip3 install --no-cache-dir -r /app/Manga-Tagger/requirements.txt && \
   mkdir /manga && \
   mkdir /downloads
 

--- a/MangaTaggerLib/api.py
+++ b/MangaTaggerLib/api.py
@@ -78,6 +78,7 @@ class AniList:
           Media (id: $series_id, type: MANGA, format: $format) {
             id
             status
+            volumes
             siteUrl
             title {
               romaji

--- a/MangaTaggerLib/models.py
+++ b/MangaTaggerLib/models.py
@@ -45,6 +45,11 @@ class Metadata:
             self.series_title_jap = anilist_details['title']['native']
 
         self.status = anilist_details['status']
+        if anilist_details.get('volumes'):
+            self.volumes = anilist_details.get('volumes')
+        else:
+            self.volumes = None
+
         self.type = anilist_details['type']
         self.description = anilist_details['description']
         self.anilist_url = anilist_details['siteUrl']
@@ -64,6 +69,7 @@ class Metadata:
         self.series_title_eng = details['series_title_eng']
         self.series_title_jap = details['series_title_jap']
         self.status = details['status']
+        self.volumes = details.get("volumes")
         self.type = details['type']
         self.description = details['description']
         self.anilist_url = details['anilist_url']
@@ -160,6 +166,7 @@ class Metadata:
             'series_title_eng': self.series_title_eng,
             'series_title_jap': self.series_title_jap,
             'status': self.status,
+            'volumes':self.volumes,
 #            'mal_url': self.mal_url,
             'anilist_url': self.anilist_url,
             'publish_date': self.publish_date,

--- a/tests/data/3D Kanojo Real Girl/data.json
+++ b/tests/data/3D Kanojo Real Girl/data.json
@@ -1,6 +1,7 @@
 {
   "id": 80767,
   "status": "FINISHED",
+  "volumes": 12,
   "siteUrl": "https://anilist.co/manga/80767",
   "title": {
 	"romaji": "3D Kanojo: Real Girl",

--- a/tests/data/BLEACH/data.json
+++ b/tests/data/BLEACH/data.json
@@ -1,44 +1,307 @@
 {
   "id": 30012,
   "status": "FINISHED",
+  "volumes": 74,
   "siteUrl": "https://anilist.co/manga/30012",
   "title": {
-	"romaji": "BLEACH",
-	"english": "Bleach",
-	"native": "ブリーチ"
+    "romaji": "BLEACH",
+    "english": "Bleach",
+    "native": "BLEACH"
   },
   "type": "MANGA",
   "genres": [
-	"Action",
-	"Adventure",
-	"Supernatural"
+    "Action",
+    "Adventure",
+    "Supernatural"
   ],
   "startDate": {
-	"day": 7,
-	"month": 8,
-	"year": 2001
+    "day": 7,
+    "month": 8,
+    "year": 2001
   },
   "coverImage": {
-	"extraLarge": "https://s4.anilist.co/file/anilistcdn/media/manga/cover/large/bx30012-z7U138mUaPdN.png"
+    "extraLarge": "https://s4.anilist.co/file/anilistcdn/media/manga/cover/large/bx30012-z7U138mUaPdN.png"
   },
   "staff": {
-	"edges": [
-	  {
-		"node": {
-		  "name": {
-			"first": "Tite",
-			"last": "Kubo",
-			"full": "Tite Kubo",
-			"alternative": [
-			  "Taito Kubo",
-			  "Noriaki Kubo (久保宣章)"
-			]
-		  },
-		  "siteUrl": "https://anilist.co/staff/96880"
-		},
-		"role": "Story & Art"
-	  }
-	]
+    "edges": [
+      {
+        "node": {
+          "name": {
+            "first": "Tite",
+            "last": "Kubo",
+            "full": "Tite Kubo",
+            "alternative": [
+              "Taito Kubo",
+              "Noriaki Kubo (\u4e45\u4fdd\u5ba3\u7ae0)"
+            ]
+          },
+          "siteUrl": "https://anilist.co/staff/96880"
+        },
+        "role": "Story & Art"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Ricardo",
+            "last": "Cruz",
+            "full": "Ricardo Cruz",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/104809"
+        },
+        "role": "Translator (Portuguese: vols 1-24)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Drik",
+            "last": "Sada",
+            "full": "Drik Sada",
+            "alternative": [
+              "Adriana Kazue Sada"
+            ]
+          },
+          "siteUrl": "https://anilist.co/staff/220675"
+        },
+        "role": "Translator (Portuguese: vols 25-52, 71-74)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Christine",
+            "last": "Dashiell",
+            "full": "Christine Dashiell",
+            "alternative": [
+              "Christine Schilling"
+            ]
+          },
+          "siteUrl": "https://anilist.co/staff/219441"
+        },
+        "role": "Translator (English: vol 49)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Joe",
+            "last": "Yamazaki",
+            "full": "Joe Yamazaki",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/218469"
+        },
+        "role": "Translator (English)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Mark",
+            "last": "McMurray",
+            "full": "Mark McMurray",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/224874"
+        },
+        "role": "Touch-up Art & Lettering (English: vols 16, 20)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Mark",
+            "last": "McMurray",
+            "full": "Mark McMurray",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/224874"
+        },
+        "role": "Lettering (English: vols: 16, 17, 19, 20, 22, 23, 24)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Evan",
+            "last": "Waldinger",
+            "full": "Evan Waldinger",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/227608"
+        },
+        "role": "Touch-up Art & Lettering (English: vol 21)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Dave",
+            "last": "Lanphear",
+            "full": "Dave Lanphear",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/227606"
+        },
+        "role": "Touch-up Art & Lettering (English: vols 3, 5, 6, 7, 8)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Andy",
+            "last": "Ristaino",
+            "full": "Andy Ristaino",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/227607"
+        },
+        "role": "Touch-up Art & Lettering (English)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Marta",
+            "last": "Gallego",
+            "full": "Marta Gallego",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/225332"
+        },
+        "role": "Translator (Spanish)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Marc",
+            "last": "Bernab\u00e9",
+            "full": "Marc Bernab\u00e9",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/214718"
+        },
+        "role": "Translator (Spanish)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Ver\u00f3nica",
+            "last": "Calafell",
+            "full": "Ver\u00f3nica Calafell",
+            "alternative": [
+              "Ver\u00f3nica Calafell Callejo"
+            ]
+          },
+          "siteUrl": "https://anilist.co/staff/225627"
+        },
+        "role": "Translator (Spanish)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Simona",
+            "last": "Stanzani",
+            "full": "Simona Stanzani",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/225407"
+        },
+        "role": "Translator (Italian)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Rafael",
+            "last": "Morata",
+            "full": "Rafael Morata",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/227609"
+        },
+        "role": "Translator (Spanish)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Daniel",
+            "last": "B\u00fcchner",
+            "full": "Daniel B\u00fcchner",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/227610"
+        },
+        "role": "Translator (German)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Kentarou",
+            "last": "Kurimoto",
+            "full": "Kentarou Kurimoto",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/119236"
+        },
+        "role": "Assistant"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Shou",
+            "last": "Aimoto",
+            "full": "Shou Aimoto",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/98753"
+        },
+        "role": "Assistant"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Hitoshi",
+            "last": "Imoto",
+            "full": "Hitoshi Imoto",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/126703"
+        },
+        "role": "Assistant"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Anne-Sophie",
+            "last": "Thevenon",
+            "full": "Anne-Sophie Thevenon",
+            "alternative": [
+              "Anne-Sophie Th\u00e9venon"
+            ]
+          },
+          "siteUrl": "https://anilist.co/staff/236835"
+        },
+        "role": "Translator (French)"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Shou",
+            "last": "Shiromoto",
+            "full": "Shou Shiromoto",
+            "alternative": []
+          },
+          "siteUrl": "https://anilist.co/staff/249345"
+        },
+        "role": "Assistant"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Tayfun",
+            "last": "Nitahara Haks\u00f6yliyen",
+            "full": "Tayfun Nitahara Haks\u00f6yliyen",
+            "alternative": [
+              "Tayfun Nitahara Haksoyliyen"
+            ]
+          },
+          "siteUrl": "https://anilist.co/staff/275233"
+        },
+        "role": "Translator (Turkish: vols 1-17)"
+      }
+    ]
   },
-  "description": "Ichigo Kurosaki has always been able to see ghosts, but this ability doesn't change his life nearly as much as his close encounter with Rukia Kuchiki, a Soul Reaper and member of the mysterious Soul Society. While fighting a Hollow, an evil spirit that preys on humans who display psychic energy, Rukia attempts to lend Ichigo some of her powers so that he can save his family; but much to her surprise, Ichigo absorbs every last drop of her energy. Now a full-fledged Soul Reaper himself, Ichigo quickly learns that the world he inhabits is one full of dangerous spirits and, along with Rukia— who is slowly regaining her powers— it's Ichigo's job to protect the innocent from Hollows and help the spirits themselves find peace.<br><br>\n(Source: Anime News Network) <br><br>\n<b>20 Included bonus chapters:</b><br>\nVolume 10 - <i>Chapter 88.5: Karakura Super Heroes.</i><br>\nVolume 12 - <i>Chapter 0.8: A Wonderful Error.</i><br>\nVolume 15 - <i>Chapter -17: Prelude for the Straying Stars.</i><br>\nVolume 20 - <i>Chapter -12.5: Blooming Under a Cold Moon.</i><br>\nVolume 23 - <i>Chapter 0.Side-A: The Sand; Chapter 0.Side-B: The Rotator.</i><br>\nVolume 32 - <i>Chapter -16: Death on the Ice Field.</i><br>\nVolume 36 - <i>Chapters -108 to -100: Turn Back the Pendulum (1-9).</i><br>\nVolume 37 - <i>Chapters -99 to -98: Turn Back the Pendulum (10-11); Chapter -97: Let Stop the Pendulum.</i><br>\nVolume 70 - <i>Chapter 520.5: Walk Under Two Letters.</i>"
+  "description": "Ichigo Kurosaki has always been able to see ghosts, but this ability doesn't change his life nearly as much as his close encounter with Rukia Kuchiki, a Soul Reaper and member of the mysterious Soul Society. While fighting a Hollow, an evil spirit that preys on humans who display psychic energy, Rukia attempts to lend Ichigo some of her powers so that he can save his family; but much to her surprise, Ichigo absorbs every last drop of her energy. Now a full-fledged Soul Reaper himself, Ichigo quickly learns that the world he inhabits is one full of dangerous spirits and, along with Rukia\u2014 who is slowly regaining her powers\u2014 it's Ichigo's job to protect the innocent from Hollows and help the spirits themselves find peace.<br><br>\n(Source: Anime News Network)<br><br>\n<i>Note: Chapter count includes the 12-chapter \u201cTurn Back The Pendulum\u201d side story and 8 extra chapters.</i>"
 }

--- a/tests/data/Hurejasik/data.json
+++ b/tests/data/Hurejasik/data.json
@@ -1,60 +1,61 @@
 {
   "id": 86964,
   "status": "FINISHED",
+  "volumes": 5,
   "siteUrl": "https://anilist.co/manga/86964",
   "title": {
-	"romaji": "Hurejasik",
-	"english": "Bastard",
-	"native": "후레자식"
+    "romaji": "Hurejasik",
+    "english": "Bastard",
+    "native": "후레자식"
   },
   "type": "MANGA",
   "genres": [
-	"Drama",
-	"Horror",
-	"Mystery",
-	"Psychological",
-	"Romance",
-	"Thriller"
+    "Drama",
+    "Horror",
+    "Mystery",
+    "Psychological",
+    "Romance",
+    "Thriller"
   ],
   "startDate": {
-	"day": 4,
-	"month": 7,
-	"year": 2014
+    "day": 4,
+    "month": 7,
+    "year": 2014
   },
   "coverImage": {
-	"extraLarge": "https://s4.anilist.co/file/anilistcdn/media/manga/cover/large/nx86964-r7S3IbJNr4SD.jpg"
+    "extraLarge": "https://s4.anilist.co/file/anilistcdn/media/manga/cover/large/nx86964-r7S3IbJNr4SD.jpg"
   },
   "staff": {
-	"edges": [
-	  {
-		"node": {
-		  "name": {
-			"first": "Youngchan",
-			"last": "Hwang",
-			"full": "Youngchan Hwang",
-			"alternative": [
-			  ""
-			]
-		  },
-		  "siteUrl": "https://anilist.co/staff/119717"
-		},
-		"role": "Art"
-	  },
-	  {
-		"node": {
-		  "name": {
-			"first": "Carnby",
-			"last": "Kim",
-			"full": "Carnby Kim",
-			"alternative": [
-			  "김칸비"
-			]
-		  },
-		  "siteUrl": "https://anilist.co/staff/119718"
-		},
-		"role": "Story"
-	  }
-	]
+    "edges": [
+      {
+        "node": {
+          "name": {
+            "first": "Yeong-chan",
+            "last": "Hwang",
+            "full": "Yeong-chan Hwang",
+            "alternative": [
+              ""
+            ]
+          },
+          "siteUrl": "https://anilist.co/staff/119717"
+        },
+        "role": "Art"
+      },
+      {
+        "node": {
+          "name": {
+            "first": "Carnby",
+            "last": "Kim",
+            "full": "Carnby Kim",
+            "alternative": [
+              "김칸비"
+            ]
+          },
+          "siteUrl": "https://anilist.co/staff/119718"
+        },
+        "role": "Story"
+      }
+    ]
   },
   "description": "There is nowhere that Seon Jin can find solace. At school, he is ruthlessly bullied due to his unsettlingly quiet nature and weak appearance. However, this is not the source of Jin's insurmountable terror: the thing that he fears more than anything else is his own father.<br><br>\nTo most, Jin's father is a successful businessman, good samaritan, and doting parent. But that is merely a facade; in truth, he is a deranged serial killer—and Jin is his unwilling accomplice. For years, they have been carrying out this ruse with the police being none the wiser. However, when his father takes an interest in the pretty transfer student Yoon Kyun, Jin must make a decision—be the coward who sends her to the gallows like all the rest, or be the bastard of a son who defies his wicked parent.<br><br>\n(Source: MAL Rewrite)<br><br>\n<i>Note: Includes the prologue.</i>"
 }

--- a/tests/data/Naruto/data.json
+++ b/tests/data/Naruto/data.json
@@ -1,9 +1,10 @@
 {
 	"id": 30011,
 	  "status": "FINISHED",
+	  "volumes": 72,
 	  "siteUrl": "https://anilist.co/manga/30011",
 	  "title": {
-		"romaji": "Naruto",
+		"romaji": "NARUTO",
 		"english": "Naruto",
 		"native": "NARUTO -ナルト-"
 	  },

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -47,7 +48,7 @@ class TestMetadata(unittest.TestCase):
 
         manga_metadata = Metadata(title, {}, anilist_details)
 
-        self.assertTrue(construct_comicinfo_xml(manga_metadata, '001', {}))
+        self.assertTrue(construct_comicinfo_xml(manga_metadata, '001', {}, None))
 
     def test_comicinfo_xml_creation_case_2(self):
         title = 'Naruto'
@@ -59,33 +60,33 @@ class TestMetadata(unittest.TestCase):
 
         manga_metadata = Metadata(title, {}, anilist_details)
 
-        self.assertTrue(construct_comicinfo_xml(manga_metadata, '001', {}))
+        self.assertTrue(construct_comicinfo_xml(manga_metadata, '001', {}, None))
 
     def test_metadata_case_1(self):
         title = 'BLEACH'
 
-        self.MangaTaggerLib_AppSettings.mode_settings = { 'write_comicinfo': False }
-        self.MangaTaggerLib_AppSettings.mode_settings = { 'rename_file': False }
+        self.MangaTaggerLib_AppSettings.mode_settings = {'write_comicinfo': False}
+        self.MangaTaggerLib_AppSettings.mode_settings = {'rename_file': False}
 
         with open(Path(self.data_dir, title, self.data_file), encoding='utf-8') as data:
             anilist_details = json.load(data)
 
         expected_manga_metadata = Metadata(title, {}, anilist_details)
-        actual_manga_metadata = metadata_tagger("NOWHERE", title, '001', "MANGA", {})
+        actual_manga_metadata = metadata_tagger("NOWHERE", title, '001', "MANGA", {}, None)
 
         self.assertEqual(expected_manga_metadata.test_value(), actual_manga_metadata.test_value())
 
     def test_metadata_case_2(self):
         title = 'Naruto'
 
-        self.MangaTaggerLib_AppSettings.mode_settings = { 'write_comicinfo': False }
-        self.MangaTaggerLib_AppSettings.mode_settings = { 'rename_file': False }
+        self.MangaTaggerLib_AppSettings.mode_settings = {'write_comicinfo': False}
+        self.MangaTaggerLib_AppSettings.mode_settings = {'rename_file': False}
 
         with open(Path(self.data_dir, title, self.data_file), encoding='utf-8') as data:
             anilist_details = json.load(data)
 
         expected_manga_metadata = Metadata(title, {}, anilist_details)
-        actual_manga_metadata = metadata_tagger("NOWHERE", title, '001', "MANGA", {})
+        actual_manga_metadata = metadata_tagger("NOWHERE", title, '001', "MANGA", {}, None)
 
         self.assertEqual(expected_manga_metadata.test_value(), actual_manga_metadata.test_value())
 
@@ -93,15 +94,15 @@ class TestMetadata(unittest.TestCase):
         title = '3D Kanojo Real Girl'
         downloaded_title = '3D Kanojo'
 
-        self.MangaTaggerLib_AppSettings.mode_settings = { 'write_comicinfo': False }
-        self.MangaTaggerLib_AppSettings.mode_settings = { 'rename_file': False }
+        self.MangaTaggerLib_AppSettings.mode_settings = {'write_comicinfo': False}
+        self.MangaTaggerLib_AppSettings.mode_settings = {'rename_file': False}
         self.MangaTaggerLib_AppSettings.adult_result = False
 
         with open(Path(self.data_dir, title, self.data_file), encoding='utf-8') as data:
             anilist_details = json.load(data)
 
         expected_manga_metadata = Metadata(title, {}, anilist_details)
-        actual_manga_metadata = metadata_tagger("NOWHERE", downloaded_title, '001', "MANGA", {})
+        actual_manga_metadata = metadata_tagger("NOWHERE", downloaded_title, '001', "MANGA", {}, None)
 
         self.assertEqual(expected_manga_metadata.test_value(), actual_manga_metadata.test_value())
 
@@ -109,27 +110,27 @@ class TestMetadata(unittest.TestCase):
         title = 'Hurejasik'
         downloaded_title = 'Bastard'
 
-        self.MangaTaggerLib_AppSettings.mode_settings = { 'write_comicinfo': False }
-        self.MangaTaggerLib_AppSettings.mode_settings = { 'rename_file': False }
+        self.MangaTaggerLib_AppSettings.mode_settings = {'write_comicinfo': False}
+        self.MangaTaggerLib_AppSettings.mode_settings = {'rename_file': False}
 
         with open(Path(self.data_dir, title, self.data_file), encoding='utf-8') as data:
             anilist_details = json.load(data)
 
         expected_manga_metadata = Metadata(title, {}, anilist_details)
-        actual_manga_metadata = metadata_tagger("NOWHERE", downloaded_title, '001', "MANGA", {})
+        actual_manga_metadata = metadata_tagger("NOWHERE", downloaded_title, '001', "MANGA", {}, None)
 
         self.assertEqual(expected_manga_metadata.test_value(), actual_manga_metadata.test_value())
 
     def test_metadata_case_5(self):
         title = 'Naruto'
 
-        self.MangaTaggerLib_AppSettings.mode_settings = { 'write_comicinfo': False }
-        self.MangaTaggerLib_AppSettings.mode_settings = { 'rename_file': False }
+        self.MangaTaggerLib_AppSettings.mode_settings = {'write_comicinfo': False}
+        self.MangaTaggerLib_AppSettings.mode_settings = {'rename_file': False}
 
         with open(Path(self.data_dir, title, self.data_file), encoding='utf-8') as data:
             anilist_details = json.load(data)
 
         expected_manga_metadata = Metadata(title, {}, anilist_details)
-        actual_manga_metadata = metadata_tagger("NOWHERE", title, '001', "ONE_SHOT", {})
+        actual_manga_metadata = metadata_tagger("NOWHERE", title, '001', "ONE_SHOT", {}, None)
 
         self.assertNotEqual(expected_manga_metadata.test_value(), actual_manga_metadata.test_value())

--- a/tests/test_manga.py
+++ b/tests/test_manga.py
@@ -15,7 +15,7 @@ class FilenameParserTestCase(unittest.TestCase):
        filename = "Naruto -.- Chap 0.cbz"
        directory_name = "Naruto"
        logging_info = { 'event_id': 0, 'manga_title': directory_name, "original_filename": filename }
-       expected_result = ("Naruto", "000", "MANGA")
+       expected_result = ("Naruto", "000", "MANGA",None)
        result = filename_parser(filename, logging_info)
        self.assertEqual(expected_result, result)
 
@@ -23,7 +23,7 @@ class FilenameParserTestCase(unittest.TestCase):
        filename = "Naruto -.- Chap 15.5.cbz"
        directory_name = "Naruto"
        logging_info = { 'event_id': 0, 'manga_title': directory_name, "original_filename": filename }
-       expected_result = ("Naruto", "015.5", "MANGA")
+       expected_result = ("Naruto", "015.5", "MANGA",None)
        result = filename_parser(filename, logging_info)
        self.assertEqual(expected_result, result)
 
@@ -32,7 +32,7 @@ class FilenameParserTestCase(unittest.TestCase):
        filename = "Naruto -.- Oneshot.cbz"
        directory_name = "Naruto"
        logging_info = { 'event_id': 0, 'manga_title': directory_name, "original_filename": filename }
-       expected_result = ("Naruto", "000", "ONE_SHOT")
+       expected_result = ("Naruto", "000", "ONE_SHOT",None)
        result = filename_parser(filename, logging_info)
        self.assertEqual(expected_result, result)
 
@@ -41,7 +41,7 @@ class FilenameParserTestCase(unittest.TestCase):
        filename = "Berserk -.- Prologue 5.cbz"
        directory_name = "Berserk"
        logging_info = { 'event_id': 0, 'manga_title': directory_name, "original_filename": filename }
-       expected_result = ("Berserk", "000.5", "MANGA")
+       expected_result = ("Berserk", "000.5", "MANGA",None)
        result = filename_parser(filename, logging_info)
        self.assertEqual(expected_result, result)
 
@@ -50,10 +50,18 @@ class FilenameParserTestCase(unittest.TestCase):
        filename = "One Piece -.- Volume 50 Episode 156 A Chapter Name (15).cbz"
        directory_name = "Naruto"
        logging_info = { 'event_id': 0, 'manga_title': directory_name, "original_filename": filename }
-       expected_result = ("One Piece", "156", "MANGA")
+       expected_result = ("One Piece", "156", "MANGA","50")
        result = filename_parser(filename, logging_info)
        self.assertEqual(expected_result, result)
 
+   def test_filename_parser_ignore_fluff_2(self):
+       ## Ignore Volume, chapter name and (part)
+       filename = "Kuma Kuma Kuma Bear -.- Ch. 064 - Kuma-san and the Shop's Opening Day 2.cbz"
+       directory_name = "Kuma Kuma Kuma Bear"
+       logging_info = {'event_id': 0, 'manga_title': directory_name, "original_filename": filename}
+       expected_result = ("Kuma Kuma Kuma Bear", "064", "MANGA", None)
+       result = filename_parser(filename, logging_info)
+       self.assertEqual(expected_result, result)
 class TestMangaRenameAction(unittest.TestCase):
     download_dir = Path('tests/downloads')
     library_dir = Path('tests/library')


### PR DESCRIPTION
# [Added: Volume, Count, localized Series, Web](https://github.com/Banh-Canh/Manga-Tagger/commit/d7808262abe7ff622343a2540727ebe48976647a)
- Parses Volume from filename
- Count if anilist shows number of volumes. (Anilist only shows total volumes when serie is marked as finished)
- Web (removed on initials commit of the fork used to be anilist web. Now will get filled with anilist web)
- Localized Series, new comicinfo.xml tag. (not yet accepted, only consumer app that consumes it currently is kavita)(unstaged, let me know if you'd like this)
# [Updated tests and added test CI](https://github.com/Banh-Canh/Manga-Tagger/commit/1cda6fff6af096f2b01d09da39109e12c23dbfab)

Closes #4 