### PR TITLE
Strip series name to remove spaces at the end

### DIFF
--- a/MangaTaggerLib/MangaTaggerLib.py
+++ b/MangaTaggerLib/MangaTaggerLib.py
@@ -622,6 +622,7 @@ def slugify(value, allow_unicode=False):
     else:
         value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
     value = re.sub(r'[^\w\s-]', '', value)
+    value = value.strip()
     return value
 
 

--- a/tests/data/Hurejasik/data.json
+++ b/tests/data/Hurejasik/data.json
@@ -30,9 +30,9 @@
       {
         "node": {
           "name": {
-            "first": "Yeong-chan",
+            "first": "Yeong-Chan",
             "last": "Hwang",
-            "full": "Yeong-chan Hwang",
+            "full": "Yeong-Chan Hwang",
             "alternative": [
               ""
             ]


### PR DESCRIPTION
Some entries from anilist do have a space at the end of it. Thus creating folders with spaces at the end and also adds a double space just before Ch.xx
current: 
```
ga Kakutei Shita  060.cbz
                 ^ double space
```



expected:
```
ga Kakutei Shita 001.cbz
                ^ single space
```

This change is prone to create duplicated folders. Due to old ones having a space at the end and new ones do not.

I just fixed this in linux using `mmv` tool
```shell
mmv "*/*  *" "#1/#2 #3"
```

then i checked for double spaces in foldernames 
```shell
ls -d *\ \ *
```
