### PR TITLE
Enhanced Exceptions, Database Searching and Manga Title Synonyms

### DIFF
--- a/MangaTaggerLib/MangaTaggerLib.py
+++ b/MangaTaggerLib/MangaTaggerLib.py
@@ -93,6 +93,7 @@ def filename_parser(filename, logging_info):
 
     manga_title: str = filename[0]
     chapter_title: str = path.splitext(filename[1].lower())[0]
+    manga_title = manga_title.strip()
     LOG.debug(f'manga_title: {manga_title}')
     LOG.debug(f'chapter: {chapter_title}')
 
@@ -276,6 +277,7 @@ def metadata_tagger(file_path, manga_title, manga_chapter_number, format, loggin
     db_exists = True
     retries = 0
     isadult = False
+    anilist_id = None
 
     if AppSettings.adult_result:
         isadult = True
@@ -289,30 +291,30 @@ def metadata_tagger(file_path, manga_title, manga_chapter_number, format, loggin
                 format = exceptions[manga_title]['format']
             if exceptions[manga_title]['adult'] is True or exceptions[manga_title]['adult'] is False:
                 isadult = exceptions[manga_title]['adult']
-            manga_title = exceptions[manga_title]['anilist_title']
+            if "anilist_id" in exceptions[manga_title]:
+                anilist_id = exceptions[manga_title]['anilist_id']
+            if "anilist_title" in exceptions[manga_title]:
+                manga_title = exceptions[manga_title]['anilist_title']
 
     LOG.info(f'Table search value is "{manga_title}"', extra=logging_info)
     while manga_search is None:
         if retries == 0:
-            LOG.info('Searching manga_metadata for manga title by search value...', extra=logging_info)
-            manga_search = MetadataTable.search_by_search_value(manga_title)
+            if anilist_id is not None:
+                LOG.info('Searching manga_metadata for anilist id.', extra=logging_info)
+                manga_search = MetadataTable.search_by_search_id(anilist_id)
+            else:
+                LOG.info('Searching manga_metadata for manga title by search value...', extra=logging_info)
+                manga_search = MetadataTable.search_by_search_value(manga_title)
             retries = 1
-        elif retries == 1:
-            LOG.info('Searching manga_metadata for regular manga title...', extra=logging_info)
-            manga_search = MetadataTable.search_by_series_title(manga_title)
-            retries = 2
-        elif retries == 2:
-            LOG.info('Searching manga_metadata for English manga title...', extra=logging_info)
-            manga_search = MetadataTable.search_by_series_title_eng(manga_title)
-            retries = 3
         else:  # The manga is not in the database, so ping the API and create the database
             LOG.info('Manga was not found in the database; resorting to Anilist API.', extra=logging_info)
-
             try:
-                if isadult:  # enable adult result in Anilist
+                if anilist_id:
+                    LOG.info('Searching based on id given in exception file. ')
+                    manga_search = AniList.search_for_manga_title_by_id(anilist_id, logging_info)
+                elif isadult:  # enable adult result in Anilist
                     LOG.info('Adult result enabled')
-                    manga_search = AniList.search_for_manga_title_by_manga_title_with_adult(manga_title, format,
-                                                                                            logging_info)
+                    manga_search = AniList.search_for_manga_title_by_manga_title_with_adult(manga_title, format, logging_info)
                 else:
                     manga_search = AniList.search_for_manga_title_by_manga_title(manga_title, format, logging_info)
             except AniListRateLimit as e:
@@ -320,10 +322,12 @@ def metadata_tagger(file_path, manga_title, manga_chapter_number, format, loggin
                 LOG.warning('Manga Tagger has unintentionally breached the API limits on Anilist. Waiting 60s to clear '
                             'all rate limiting limits...')
                 time.sleep(60)
-                if isadult:  # enable adult result in Anilist
+                if anilist_id:
+                    LOG.info('Searching based on id given in exception file: ')
+                    manga_search = AniList.search_for_manga_title_by_id(anilist_id, logging_info)
+                elif isadult:  # enable adult result in Anilist
                     LOG.info('Adult result enabled')
-                    manga_search = AniList.search_for_manga_title_by_manga_title_with_adult(manga_title, format,
-                                                                                            logging_info)
+                    manga_search = AniList.search_for_manga_title_by_manga_title_with_adult(manga_title, format, logging_info)
                 else:
                     manga_search = AniList.search_for_manga_title_by_manga_title(manga_title, format, logging_info)
             if manga_search is None:
@@ -380,11 +384,19 @@ def metadata_tagger(file_path, manga_title, manga_chapter_number, format, loggin
                      extra=logging_info)
             ProcSeriesTable.processed_series.add(manga_title)
 
-        if AppSettings.image and not Path(f'{AppSettings.image_dir}/{series_title}_cover.jpg').exists():
-            LOG.info(f'Image directory configured but cover not found. Send request to Anilist for necessary data.',
-                     extra=logging_info)
-            manga_id = MetadataTable.search_id_by_search_value(series_title)
-            anilist_details = AniList.search_staff_by_mal_id(manga_id, logging_info)
+        if AppSettings.image:
+            if not Path(f'{AppSettings.image_dir}/{series_title}_cover.jpg').exists():
+                LOG.info(f'Image directory configured but cover not found. Send request to Anilist for necessary data.',extra=logging_info)
+                manga_id = MetadataTable.search_by_series_title(series_title)['_id']
+                anilist_details = AniList.search_details_by_series_id(manga_id, format, logging_info)
+                LOG.info('Downloading series cover image...', extra=logging_info)
+                download_cover_image(series_title, anilist_details['coverImage']['extraLarge'])
+            else:
+                LOG.info('Series cover image already exist, not downloading.', extra=logging_info)
+        else:
+            LOG.info('Image flag not set, not downloading series cover image.', extra=logging_info)
+
+
 
         manga_metadata = Metadata(series_title, logging_info, details=manga_search)
         logging_info['metadata'] = manga_metadata.__dict__
@@ -469,18 +481,16 @@ def metadata_tagger(file_path, manga_title, manga_chapter_number, format, loggin
 
     if AppSettings.mode_settings is None or ('write_comicinfo' in AppSettings.mode_settings.keys()
                                              and AppSettings.mode_settings['write_comicinfo']):
-
         if AppSettings.image:
             if not Path(f'{AppSettings.image_dir}/{series_title}_cover.jpg').exists():
-                LOG.info('Downloading series cover image...', extra=logging_info)
+                LOG.info(f'Image directory configured but cover not found. Downloading series cover image...', extra=logging_info)
                 download_cover_image(series_title, anilist_details['coverImage']['extraLarge'])
             else:
-                LOG.info('Serie cover image already exist, not downloading.', extra=logging_info)
-        else:
-            LOG.info('Image Directory not set, not downloading series cover image.', extra=logging_info)
-
+                LOG.info('Series cover image already exist, not downloading.', extra=logging_info)
         comicinfo_xml = construct_comicinfo_xml(manga_metadata, manga_chapter_number, logging_info, volume)
         reconstruct_manga_chapter(series_title, comicinfo_xml, new_file_path, logging_info)
+        if AppSettings.image and (not AppSettings.image_first or (AppSettings.image_first and int(float(manga_chapter_number))==1)):
+            add_cover_to_manga_chapter(series_title, new_file_path, logging_info)
 
     LOG.info(f'Processing on "{new_file_path}" has finished.', extra=logging_info)
     return manga_metadata
@@ -590,17 +600,25 @@ def construct_comicinfo_xml(metadata: Metadata, chapter_number, logging_info, vo
 def reconstruct_manga_chapter(manga_title, comicinfo_xml, manga_file_path, logging_info):
     try:
         with ZipFile(manga_file_path, 'a') as zipfile:
-            if AppSettings.image and Path(f'{AppSettings.image_dir}/{manga_title}_cover.jpg').exists():
-                zipfile.write(f'{AppSettings.image_dir}/{manga_title}_cover.jpg', '000_cover.jpg')
             zipfile.writestr('ComicInfo.xml', comicinfo_xml)
     except Exception as e:
         LOG.exception(e, extra=logging_info)
         LOG.warning('Manga Tagger is unfamiliar with this error. Please log an issue for investigation.',
                     extra=logging_info)
         return
-
     LOG.info(f'ComicInfo.xml has been created and appended to "{manga_file_path}".', extra=logging_info)
 
+def add_cover_to_manga_chapter(manga_title, manga_file_path, logging_info):
+    try:
+        with ZipFile(manga_file_path, 'a') as zipfile:
+            if AppSettings.image and Path(f'{AppSettings.image_dir}/{manga_title}_cover.jpg').exists():
+                zipfile.write(f'{AppSettings.image_dir}/{manga_title}_cover.jpg', '000_cover.jpg')
+    except Exception as e:
+        LOG.exception(e, extra=logging_info)
+        LOG.warning('Manga Tagger is unfamiliar with this error. Please log an issue for investigation.',
+                    extra=logging_info)
+        return
+    LOG.info(f'Cover Image has been added to "{manga_file_path}".', extra=logging_info)
 
 def download_cover_image(manga_title, image_url):
     image = requests.get(image_url)

--- a/MangaTaggerLib/api.py
+++ b/MangaTaggerLib/api.py
@@ -32,6 +32,28 @@ class AniList:
             return None
 
     @classmethod
+    def search_for_manga_title_by_id(cls, manga_id, logging_info):
+        query = '''
+        query search_for_manga_title_by_id ($manga_id: Int) {
+          Media (id: $manga_id, type: MANGA) {
+            id
+            title {
+              romaji
+              english
+              native
+            }
+            synonyms
+          }
+        }
+        '''
+
+        variables = {
+            'manga_id': manga_id,
+        }
+
+        return cls._post(query, variables, logging_info)
+
+    @classmethod
     def search_for_manga_title_by_manga_title(cls, manga_title, format, logging_info):
         query = '''
         query search_manga_by_manga_title ($manga_title: String, $format: MediaFormat) {
@@ -42,6 +64,7 @@ class AniList:
               english
               native
             }
+            synonyms
           }
         }
         '''
@@ -64,6 +87,7 @@ class AniList:
               english
               native
             }
+            synonyms
           }
         }
         '''
@@ -91,6 +115,7 @@ class AniList:
             }
             type
             genres
+            synonyms
             startDate {
               day
               month

--- a/MangaTaggerLib/database.py
+++ b/MangaTaggerLib/database.py
@@ -154,27 +154,6 @@ class MetadataTable(Database):
             {'synonyms': manga_title}
         ]})
 
-    # @classmethod
-    # def search_by_series_title_eng(cls, manga_title):
-    #     cls._log.debug(
-    #         f'Searching manga_metadata cls by key "series_title_eng" using value "{manga_title}"')
-    #     return cls._database.find_one({
-    #         'series_title_eng': manga_title
-    #     })
-    #
-    # @classmethod
-    # def search_by_series_title(cls, manga_title):
-    #     cls._log.debug(f'Searching manga_metadata cls by key "series_title" using value "{manga_title}"')
-    #     return cls._database.find_one({
-    #         'series_title': manga_title
-    #     })
-    #
-    # @classmethod
-    # def search_by_series_synonym(cls, manga_title):
-    #     cls._log.debug(f'Searching manga_metadata cls by key "synonyms" using value "{manga_title}"')
-    #     return cls._database.find_one({
-    #         'synonyms': manga_title
-    #     })
 
     @classmethod
     def search_id_by_search_value(cls, manga_title):

--- a/MangaTaggerLib/database.py
+++ b/MangaTaggerLib/database.py
@@ -192,26 +192,6 @@ class MetadataTable(Database):
             {'series_title_jap': manga_title},
             {'synonyms': manga_title}
         ]}, {'series_title': 1})['series_title']
-        # cursor = None
-        # retries = 0
-        # while cursor == 'None' or cursor is None:
-        #     if retries == 0:
-        #         cursor = cls._database.find_one({"search_value": manga_title}, {"series_title": 1})
-        #         retries = 1
-        #     elif retries == 1:
-        #         cursor = cls._database.find_one({"series_title": manga_title}, {"series_title": 1})
-        #         retries = 2
-        #     elif retries == 2:
-        #         cursor = cls._database.find_one({"series_title_eng": manga_title}, {"series_title": 1})
-        #         retries = 3
-        #     elif retries == 3:
-        #         cursor = cls._database.find_one({"series_title_jap": manga_title}, {"series_title": 1})
-        #         retries = 4
-        #     elif retries == 4:
-        #         cursor = cls._database.find_one({"synonyms": manga_title}, {"series_title": 1})
-        #     else:
-        #         cls._log.info(f'Can not find series_title !!')
-        #return cursor['series_title']
 
 class ProcFilesTable(Database):
     @classmethod

--- a/MangaTaggerLib/database.py
+++ b/MangaTaggerLib/database.py
@@ -137,27 +137,45 @@ class MetadataTable(Database):
         cls._log.debug(f'{cls.__name__} class has been initialized')
 
     @classmethod
+    def search_by_search_id(cls, manga_id):
+        cls._log.debug(f'Searching manga_metadata cls by key "_id" using value "{manga_id}"')
+        return cls._database.find_one({
+            '_id': manga_id
+        })
+
+    @classmethod
     def search_by_search_value(cls, manga_title):
         cls._log.debug(f'Searching manga_metadata cls by key "search_value" using value "{manga_title}"')
-        return cls._database.find_one({
-            'search_value': manga_title
-        })
+        return cls._database.find_one({'$or': [
+            {'search_value': manga_title},
+            {'series_title': manga_title},
+            {'series_title_eng': manga_title},
+            {'series_title_jap': manga_title},
+            {'synonyms': manga_title}
+        ]})
 
-    @classmethod
-    def search_by_series_title_eng(cls, manga_title):
-        cls._log.debug(
-            f'Searching manga_metadata cls by key "series_title_eng" using value "{manga_title}"')
-        return cls._database.find_one({
-            'series_title_eng': manga_title
-        })
+    # @classmethod
+    # def search_by_series_title_eng(cls, manga_title):
+    #     cls._log.debug(
+    #         f'Searching manga_metadata cls by key "series_title_eng" using value "{manga_title}"')
+    #     return cls._database.find_one({
+    #         'series_title_eng': manga_title
+    #     })
+    #
+    # @classmethod
+    # def search_by_series_title(cls, manga_title):
+    #     cls._log.debug(f'Searching manga_metadata cls by key "series_title" using value "{manga_title}"')
+    #     return cls._database.find_one({
+    #         'series_title': manga_title
+    #     })
+    #
+    # @classmethod
+    # def search_by_series_synonym(cls, manga_title):
+    #     cls._log.debug(f'Searching manga_metadata cls by key "synonyms" using value "{manga_title}"')
+    #     return cls._database.find_one({
+    #         'synonyms': manga_title
+    #     })
 
-    @classmethod
-    def search_by_series_title(cls, manga_title):
-        cls._log.debug(f'Searching manga_metadata cls by key "series_title" using value "{manga_title}"')
-        return cls._database.find_one({
-            'series_title': manga_title
-        })
-    
     @classmethod
     def search_id_by_search_value(cls, manga_title):
         cls._log.debug(f'Searching "series_id" using value "{manga_title}"')
@@ -167,23 +185,33 @@ class MetadataTable(Database):
     @classmethod
     def search_series_title(cls, manga_title):
         cls._log.debug(f'Searching "series_title" using value "{manga_title}"')
-        cursor = None
-        retries = 0
-        while cursor == 'None' or cursor is None:
-            if retries == 0:
-                cursor = cls._database.find_one({"search_value": manga_title}, {"series_title": 1})
-                retries = 1
-            elif retries == 1:
-                cursor = cls._database.find_one({"series_title": manga_title}, {"series_title": 1})
-                retries = 2
-            elif retries == 2:
-                cursor = cls._database.find_one({"series_title_eng": manga_title}, {"series_title": 1})
-                retries = 3
-            elif retries == 3:
-                cursor = cls._database.find_one({"series_title_jap": manga_title}, {"series_title": 1})
-            else:
-                cls._log.info(f'Can not find series_title !!')
-        return cursor['series_title']
+        return cls._database.find_one({"$or": [
+            {'search_value': manga_title},
+            {'series_title': manga_title},
+            {'series_title_eng': manga_title},
+            {'series_title_jap': manga_title},
+            {'synonyms': manga_title}
+        ]}, {'series_title': 1})['series_title']
+        # cursor = None
+        # retries = 0
+        # while cursor == 'None' or cursor is None:
+        #     if retries == 0:
+        #         cursor = cls._database.find_one({"search_value": manga_title}, {"series_title": 1})
+        #         retries = 1
+        #     elif retries == 1:
+        #         cursor = cls._database.find_one({"series_title": manga_title}, {"series_title": 1})
+        #         retries = 2
+        #     elif retries == 2:
+        #         cursor = cls._database.find_one({"series_title_eng": manga_title}, {"series_title": 1})
+        #         retries = 3
+        #     elif retries == 3:
+        #         cursor = cls._database.find_one({"series_title_jap": manga_title}, {"series_title": 1})
+        #         retries = 4
+        #     elif retries == 4:
+        #         cursor = cls._database.find_one({"synonyms": manga_title}, {"series_title": 1})
+        #     else:
+        #         cls._log.info(f'Can not find series_title !!')
+        #return cursor['series_title']
 
 class ProcFilesTable(Database):
     @classmethod

--- a/MangaTaggerLib/models.py
+++ b/MangaTaggerLib/models.py
@@ -55,10 +55,12 @@ class Metadata:
         self.anilist_url = anilist_details['siteUrl']
         self.publish_date = None
         self.genres = []
+        self.synonyms = []
         self.staff = {}
 
         self._construct_publish_date(anilist_details['startDate'])
         self._parse_genres(anilist_details['genres'], logging_info)
+        self._parse_synonyms(anilist_details['synonyms'], logging_info)
         self._parse_staff(anilist_details['staff']['edges'], logging_info)
 
         self.scrape_date = timezone(AppSettings.timezone).localize(datetime.now()).strftime('%Y-%m-%d %I:%M %p %Z')
@@ -75,6 +77,7 @@ class Metadata:
         self.anilist_url = details['anilist_url']
         self.publish_date = details['publish_date']
         self.genres = details['genres']
+        self.synonyms = details['synonyms']
         self.staff = details['staff']
         self.publish_date = details['publish_date']
         self.scrape_date = details['scrape_date']
@@ -93,6 +96,12 @@ class Metadata:
         for genre in genres:
             Metadata._log.debug(f'Genre found: {genre}')
             self.genres.append(genre)
+
+    def _parse_synonyms(self, synonyms, logging_info):
+        Metadata._log.info('Parsing Synonyms...', extra=logging_info)
+        for synonym in synonyms:
+            Metadata._log.debug(f'Synonym found: {synonym}')
+            self.synonyms.append(synonym)
 
     def _parse_staff(self, anilist_staff, logging_info):
         Metadata._log.info('Parsing staff roles...', extra=logging_info)
@@ -171,6 +180,7 @@ class Metadata:
             'anilist_url': self.anilist_url,
             'publish_date': self.publish_date,
             'genres': self.genres,
+            'synonyms': self.synonyms,
             'staff': self.staff,
 #            'serializations': self.serializations
         }

--- a/MangaTaggerLib/models.py
+++ b/MangaTaggerLib/models.py
@@ -93,15 +93,13 @@ class Metadata:
 
     def _parse_genres(self, genres, logging_info):
         Metadata._log.info('Parsing genres...', extra=logging_info)
-        for genre in genres:
-            Metadata._log.debug(f'Genre found: {genre}')
-            self.genres.append(genre)
+        Metadata._log.debug(f'Genre found: {", ".join(genres)}')
+        self.genres.extend(genres)
 
     def _parse_synonyms(self, synonyms, logging_info):
         Metadata._log.info('Parsing Synonyms...', extra=logging_info)
-        for synonym in synonyms:
-            Metadata._log.debug(f'Synonym found: {synonym}')
-            self.synonyms.append(synonym)
+        Metadata._log.debug(f'Synonyms found: {", ".join(synonyms)}')
+        self.synonyms.extend(synonyms)
 
     def _parse_staff(self, anilist_staff, logging_info):
         Metadata._log.info('Parsing staff roles...', extra=logging_info)

--- a/MangaTaggerLib/utils.py
+++ b/MangaTaggerLib/utils.py
@@ -22,6 +22,7 @@ class AppSettings:
     timezone = None
     version = None
     image = False
+    image_first = False
     adult_result = False
     download_dir = None
     image_dir = None
@@ -104,6 +105,9 @@ class AppSettings:
             if os.getenv("MANGA_TAGGER_IMAGE_COVER") is not None:
                 if os.getenv("MANGA_TAGGER_IMAGE_COVER").lower() == 'true':
                     settings['application']['image']['enabled'] = True
+                elif os.getenv("MANGA_TAGGER_IMAGE_COVER").lower() == 'first':
+                    settings['application']['image']['enabled'] = True
+                    settings['application']['image']['first'] = True
                 elif os.getenv("MANGA_TAGGER_IMAGE_COVER").lower() == 'false':
                     settings['application']['image']['enabled'] = False
             if os.getenv("MANGA_TAGGER_IMAGE_DIR") is not None:
@@ -220,6 +224,8 @@ class AppSettings:
         # Image Directory
         if settings['application']['image']['enabled']:
             cls.image = True
+            if settings['application']['image']['first']:
+                cls.image_first = True
             if settings['application']['image']['image_dir'] is not None:
                 if settings['application']['image']['image_dir'] is not None:
                     cls.image_dir = settings['application']['image']['image_dir']


### PR DESCRIPTION
Added the ability to add the cover image to only the first chapter of a manga. To implement in docker set the environment variable MANGA_TAGGER_IMAGE_COVER=First
Options are now:
True, False or First

Added anilist_id to the exceptions.json to assist with duplicate series with the same name. For instance Sweet Home has 2 entries on Anilist.  The one written by Kim Carnby can be tagged using this example json: {
  "Sweet Home (KIM Carnby)": {
    "anilist_id": 100954,
    "format": "MANGA",
    "adult": false
  }}
ID is first searched before title if both are entered. The anilist_id can be found in the anilist URL.

Added synonyms to the list of fetched data from AniList API.  This is then added to manga_tagger .manga_metadata as an array, which is searched against with manga_titles.

refactored database search_by_value, to search the manga_title against all fields that might contain the title as opposed to looping through and searching one at a time.

Strip extra whitespace in the manga_title.