### PR TITLE
Enhanced Exceptions, Database Searching and Manga Title Synonyms

### DIFF
--- a/MangaTaggerLib/api.py
+++ b/MangaTaggerLib/api.py
@@ -32,6 +32,28 @@ class AniList:
             return None
 
     @classmethod
+    def search_for_manga_title_by_id(cls, manga_id, logging_info):
+        query = '''
+        query search_for_manga_title_by_id ($manga_id: Int) {
+          Media (id: $manga_id, type: MANGA) {
+            id
+            title {
+              romaji
+              english
+              native
+            }
+            synonyms
+          }
+        }
+        '''
+
+        variables = {
+            'manga_id': manga_id,
+        }
+
+        return cls._post(query, variables, logging_info)
+
+    @classmethod
     def search_for_manga_title_by_manga_title(cls, manga_title, format, logging_info):
         query = '''
         query search_manga_by_manga_title ($manga_title: String, $format: MediaFormat) {
@@ -42,6 +64,7 @@ class AniList:
               english
               native
             }
+            synonyms
           }
         }
         '''
@@ -64,6 +87,7 @@ class AniList:
               english
               native
             }
+            synonyms
           }
         }
         '''
@@ -91,6 +115,7 @@ class AniList:
             }
             type
             genres
+            synonyms
             startDate {
               day
               month

--- a/MangaTaggerLib/database.py
+++ b/MangaTaggerLib/database.py
@@ -137,27 +137,23 @@ class MetadataTable(Database):
         cls._log.debug(f'{cls.__name__} class has been initialized')
 
     @classmethod
+    def search_by_search_id(cls, manga_id):
+        cls._log.debug(f'Searching manga_metadata cls by key "_id" using value "{manga_id}"')
+        return cls._database.find_one({
+            '_id': manga_id
+        })
+
+    @classmethod
     def search_by_search_value(cls, manga_title):
         cls._log.debug(f'Searching manga_metadata cls by key "search_value" using value "{manga_title}"')
-        return cls._database.find_one({
-            'search_value': manga_title
-        })
+        return cls._database.find_one({'$or': [
+            {'search_value': manga_title},
+            {'series_title': manga_title},
+            {'series_title_eng': manga_title},
+            {'series_title_jap': manga_title},
+            {'synonyms': manga_title}
+        ]})
 
-    @classmethod
-    def search_by_series_title_eng(cls, manga_title):
-        cls._log.debug(
-            f'Searching manga_metadata cls by key "series_title_eng" using value "{manga_title}"')
-        return cls._database.find_one({
-            'series_title_eng': manga_title
-        })
-
-    @classmethod
-    def search_by_series_title(cls, manga_title):
-        cls._log.debug(f'Searching manga_metadata cls by key "series_title" using value "{manga_title}"')
-        return cls._database.find_one({
-            'series_title': manga_title
-        })
-    
     @classmethod
     def search_id_by_search_value(cls, manga_title):
         cls._log.debug(f'Searching "series_id" using value "{manga_title}"')
@@ -167,23 +163,14 @@ class MetadataTable(Database):
     @classmethod
     def search_series_title(cls, manga_title):
         cls._log.debug(f'Searching "series_title" using value "{manga_title}"')
-        cursor = None
-        retries = 0
-        while cursor == 'None' or cursor is None:
-            if retries == 0:
-                cursor = cls._database.find_one({"search_value": manga_title}, {"series_title": 1})
-                retries = 1
-            elif retries == 1:
-                cursor = cls._database.find_one({"series_title": manga_title}, {"series_title": 1})
-                retries = 2
-            elif retries == 2:
-                cursor = cls._database.find_one({"series_title_eng": manga_title}, {"series_title": 1})
-                retries = 3
-            elif retries == 3:
-                cursor = cls._database.find_one({"series_title_jap": manga_title}, {"series_title": 1})
-            else:
-                cls._log.info(f'Can not find series_title !!')
-        return cursor['series_title']
+        return cls._database.find_one({"$or": [
+            {'search_value': manga_title},
+            {'series_title': manga_title},
+            {'series_title_eng': manga_title},
+            {'series_title_jap': manga_title},
+            {'synonyms': manga_title}
+        ]}, {'series_title': 1})['series_title']
+
 
 class ProcFilesTable(Database):
     @classmethod

--- a/MangaTaggerLib/models.py
+++ b/MangaTaggerLib/models.py
@@ -55,10 +55,12 @@ class Metadata:
         self.anilist_url = anilist_details['siteUrl']
         self.publish_date = None
         self.genres = []
+        self.synonyms = []
         self.staff = {}
 
         self._construct_publish_date(anilist_details['startDate'])
         self._parse_genres(anilist_details['genres'], logging_info)
+        self._parse_synonyms(anilist_details.get('synonyms'), logging_info)
         self._parse_staff(anilist_details['staff']['edges'], logging_info)
 
         self.scrape_date = timezone(AppSettings.timezone).localize(datetime.now()).strftime('%Y-%m-%d %I:%M %p %Z')
@@ -75,6 +77,7 @@ class Metadata:
         self.anilist_url = details['anilist_url']
         self.publish_date = details['publish_date']
         self.genres = details['genres']
+        self.synonyms = details['synonyms']
         self.staff = details['staff']
         self.publish_date = details['publish_date']
         self.scrape_date = details['scrape_date']
@@ -90,9 +93,13 @@ class Metadata:
 
     def _parse_genres(self, genres, logging_info):
         Metadata._log.info('Parsing genres...', extra=logging_info)
-        for genre in genres:
-            Metadata._log.debug(f'Genre found: {genre}')
-            self.genres.append(genre)
+        Metadata._log.debug(f'Genre found: {", ".join(genres)}')
+        self.genres.extend(genres)
+
+    def _parse_synonyms(self, synonyms, logging_info):
+        Metadata._log.info('Parsing Synonyms...', extra=logging_info)
+        Metadata._log.debug(f'Synonyms found: {synonyms}')
+        self.synonyms.extend(synonyms or [])
 
     def _parse_staff(self, anilist_staff, logging_info):
         Metadata._log.info('Parsing staff roles...', extra=logging_info)
@@ -171,6 +178,7 @@ class Metadata:
             'anilist_url': self.anilist_url,
             'publish_date': self.publish_date,
             'genres': self.genres,
+            'synonyms': self.synonyms,
             'staff': self.staff,
 #            'serializations': self.serializations
         }

--- a/MangaTaggerLib/utils.py
+++ b/MangaTaggerLib/utils.py
@@ -224,7 +224,7 @@ class AppSettings:
         # Image Directory
         if settings['application']['image']['enabled']:
             cls.image = True
-            if settings['application']['image']['first']:
+            if settings['application']['image'].get('first'):
                 cls.image_first = True
             if settings['application']['image']['image_dir'] is not None:
                 if settings['application']['image']['image_dir'] is not None:

--- a/MangaTaggerLib/utils.py
+++ b/MangaTaggerLib/utils.py
@@ -22,6 +22,7 @@ class AppSettings:
     timezone = None
     version = None
     image = False
+    image_first = False
     adult_result = False
     download_dir = None
     image_dir = None
@@ -104,6 +105,9 @@ class AppSettings:
             if os.getenv("MANGA_TAGGER_IMAGE_COVER") is not None:
                 if os.getenv("MANGA_TAGGER_IMAGE_COVER").lower() == 'true':
                     settings['application']['image']['enabled'] = True
+                elif os.getenv("MANGA_TAGGER_IMAGE_COVER").lower() == 'first':
+                    settings['application']['image']['enabled'] = True
+                    settings['application']['image']['first'] = True
                 elif os.getenv("MANGA_TAGGER_IMAGE_COVER").lower() == 'false':
                     settings['application']['image']['enabled'] = False
             if os.getenv("MANGA_TAGGER_IMAGE_DIR") is not None:
@@ -220,6 +224,8 @@ class AppSettings:
         # Image Directory
         if settings['application']['image']['enabled']:
             cls.image = True
+            if settings['application']['image']['first']:
+                cls.image_first = True
             if settings['application']['image']['image_dir'] is not None:
                 if settings['application']['image']['image_dir'] is not None:
                     cls.image_dir = settings['application']['image']['image_dir']

--- a/tests/data/3D Kanojo Real Girl/data.json
+++ b/tests/data/3D Kanojo Real Girl/data.json
@@ -1,6 +1,7 @@
 {
   "id": 80767,
   "status": "FINISHED",
+  "synonyms": ["3D Girlfriend"],
   "volumes": 13,
   "siteUrl": "https://anilist.co/manga/80767",
   "title": {

--- a/tests/data/BLEACH/data.json
+++ b/tests/data/BLEACH/data.json
@@ -1,6 +1,7 @@
 {
   "id": 30012,
   "status": "FINISHED",
+  "synonyms": ["ブリーチ", "بلیچ", "سفید کننده"],
   "volumes": 74,
   "siteUrl": "https://anilist.co/manga/30012",
   "title": {

--- a/tests/data/Hurejasik/data.json
+++ b/tests/data/Hurejasik/data.json
@@ -1,6 +1,7 @@
 {
   "id": 86964,
   "status": "FINISHED",
+  "synonyms": ["BASTARD", "不肖子", "Ублюдок", "Bâtard", "Bastardo", "バスタード"],
   "volumes": 5,
   "siteUrl": "https://anilist.co/manga/86964",
   "title": {

--- a/tests/data/Naruto/data.json
+++ b/tests/data/Naruto/data.json
@@ -1,6 +1,7 @@
 {
 	"id": 30011,
 	  "status": "FINISHED",
+	  "synonyms": ["נארוטו", "Наруто"],
 	  "volumes": 72,
 	  "siteUrl": "https://anilist.co/manga/30011",
 	  "title": {


### PR DESCRIPTION
# Added:
- Option to only download and append the cover to the chapter 1 (hardcoded)
To implement in docker set the environment variable `MANGA_TAGGER_IMAGE_COVER=First`. Current options are <`True` | `False` | `First`>
- Added paramenter `anilist_id` in exceptions.json to assist with duplicate series with the same name. For instance Sweet Home has 2 entries on Anilist. The one written by Kim Carnby can be tagged using this example json: 
```json
{
    "Sweet Home (KIM Carnby)": {
        "anilist_id": 100954,
        "format": "MANGA",
        "adult": false
    }
}
```
# Changed
- Added synonyms to the list of fetched data from AniList API. 
    + Refactored database search_by_value, to search the manga_title against all fields that might contain the title instead of making request per field (title, title_english, title_english_adult)
- Strip extra whitespace in the manga_title when parsing filename